### PR TITLE
Reflect derivation in License

### DIFF
--- a/citizen_code_of_conduct.md
+++ b/citizen_code_of_conduct.md
@@ -77,7 +77,7 @@ Email: kalv@vanruby.org
 
 ## 10. License and attribution
 
-The Citizen Code of Conduct is distributed by [Stumptown Syndicate](http://stumptownsyndicate.org) under a [Creative Commons Attribution-ShareAlike license](http://creativecommons.org/licenses/by-sa/3.0/). 
+Portions of text derived from the [Citizen Code of Conduct](http://citizencodeofconduct.org/), distributed by [Stumptown Syndicate](http://stumptownsyndicate.org). Distributed by [YVRDev](https://github.com/YVRDev/policies) under a [Creative Commons Attribution-ShareAlike license](http://creativecommons.org/licenses/by-sa/3.0/). 
 
 Portions of text derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/) and the [Geek Feminism Anti-Harassment Policy](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy).
 


### PR DESCRIPTION
This is not the original Stumptown Syndicate Citizen Code of Conduct - it's a derivative. The license should reflect that it's not exactly their words.